### PR TITLE
Implementation as packages and register pattern

### DIFF
--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/src-d/go-queue.v0"
+	"gopkg.in/src-d/go-queue.v0/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	queue "gopkg.in/src-d/go-queue.v0"
-	"gopkg.in/src-d/go-queue.v0/test"
 )
 
 func TestAMQPSuite(t *testing.T) {

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -30,7 +30,7 @@ func (s *AMQPSuite) SetupSuite() {
 func TestNewAMQPBroker_bad_url(t *testing.T) {
 	assert := assert.New(t)
 
-	b, err := NewAMQPBroker("badurl")
+	b, err := New("badurl")
 	assert.Error(err)
 	assert.Nil(b)
 }
@@ -50,7 +50,7 @@ func sendJobs(assert *assert.Assertions, n int, p queue.Priority, q queue.Queue)
 func TestAMQPPriorities(t *testing.T) {
 	assert := assert.New(t)
 
-	broker, err := NewAMQPBroker(testAMQPURI)
+	broker, err := New(testAMQPURI)
 	assert.NoError(err)
 	if !assert.NotNil(broker) {
 		return
@@ -162,7 +162,7 @@ func TestAMQPRepublishBuried(t *testing.T) {
 	q, err := broker.Queue(queueName)
 	require.NoError(t, err)
 
-	amqpQueue, ok := q.(*AMQPQueue)
+	amqpQueue, ok := q.(*Queue)
 	require.True(t, ok)
 
 	buried := amqpQueue.buriedQueue

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	queue "gopkg.in/src-d/go-queue.v0"
+	"gopkg.in/src-d/go-queue.v0/test"
 )
 
 func TestAMQPSuite(t *testing.T) {
@@ -15,8 +17,10 @@ func TestAMQPSuite(t *testing.T) {
 }
 
 type AMQPSuite struct {
-	QueueSuite
+	test.QueueSuite
 }
+
+const testAMQPURI = "amqp://localhost:5672"
 
 func (s *AMQPSuite) SetupSuite() {
 	s.BrokerURI = testAMQPURI
@@ -30,9 +34,9 @@ func TestNewAMQPBroker_bad_url(t *testing.T) {
 	assert.Nil(b)
 }
 
-func sendJobs(assert *assert.Assertions, n int, p Priority, q Queue) {
+func sendJobs(assert *assert.Assertions, n int, p queue.Priority, q queue.Queue) {
 	for i := 0; i < n; i++ {
-		j, err := NewJob()
+		j, err := queue.NewJob()
 		assert.NoError(err)
 		j.SetPriority(p)
 		err = j.Encode(i)
@@ -47,18 +51,20 @@ func TestAMQPPriorities(t *testing.T) {
 
 	broker, err := NewAMQPBroker(testAMQPURI)
 	assert.NoError(err)
-	assert.NotNil(broker)
+	if !assert.NotNil(broker) {
+		return
+	}
 
-	name := newName()
+	name := test.NewName()
 	q, err := broker.Queue(name)
 	assert.NoError(err)
 	assert.NotNil(q)
 
 	// Send 50 low priority jobs
-	sendJobs(assert, 50, PriorityLow, q)
+	sendJobs(assert, 50, queue.PriorityLow, q)
 
 	// Send 50 high priority jobs
-	sendJobs(assert, 50, PriorityUrgent, q)
+	sendJobs(assert, 50, queue.PriorityUrgent, q)
 
 	// Receive and collect priorities
 	iter, err := q.Consume(1)
@@ -81,16 +87,16 @@ func TestAMQPPriorities(t *testing.T) {
 	}
 
 	assert.True(sumFirst > sumLast)
-	assert.Equal(uint(PriorityUrgent)*50, sumFirst)
-	assert.Equal(uint(PriorityLow)*50, sumLast)
+	assert.Equal(uint(queue.PriorityUrgent)*50, sumFirst)
+	assert.Equal(uint(queue.PriorityLow)*50, sumLast)
 }
 
 func TestAMQPHeaders(t *testing.T) {
-	broker, err := NewBroker(testAMQPURI)
+	broker, err := queue.NewBroker(testAMQPURI)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, broker.Close()) }()
 
-	queue, err := broker.Queue(newName())
+	q, err := broker.Queue(test.NewName())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -121,17 +127,17 @@ func TestAMQPHeaders(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		job, err := NewJob()
+		job, err := queue.NewJob()
 		require.NoError(t, err)
 
 		job.Retries = test.retries
 		job.ErrorType = test.errorType
 
 		require.NoError(t, job.Encode(i))
-		require.NoError(t, queue.Publish(job))
+		require.NoError(t, q.Publish(job))
 	}
 
-	jobIter, err := queue.Consume(len(tests))
+	jobIter, err := q.Consume(len(tests))
 	require.NoError(t, err)
 
 	for _, test := range tests {
@@ -147,15 +153,15 @@ func TestAMQPHeaders(t *testing.T) {
 }
 
 func TestAMQPRepublishBuried(t *testing.T) {
-	broker, err := NewBroker(testAMQPURI)
+	broker, err := queue.NewBroker(testAMQPURI)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, broker.Close()) }()
 
-	queueName := newName()
-	queue, err := broker.Queue(queueName)
+	queueName := test.NewName()
+	q, err := broker.Queue(queueName)
 	require.NoError(t, err)
 
-	amqpQueue, ok := queue.(*AMQPQueue)
+	amqpQueue, ok := q.(*AMQPQueue)
 	require.True(t, ok)
 
 	buried := amqpQueue.buriedQueue
@@ -170,29 +176,29 @@ func TestAMQPRepublishBuried(t *testing.T) {
 		{name: "message 3", payload: "payload 4"},
 	}
 
-	for _, test := range tests {
-		job, err := NewJob()
+	for _, utest := range tests {
+		job, err := queue.NewJob()
 		require.NoError(t, err)
 
-		job.raw = []byte(test.payload)
+		job.Raw = []byte(utest.payload)
 
 		err = buried.Publish(job)
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
 	}
 
-	var condition RepublishConditionFunc = func(j *Job) bool {
-		return string(j.raw) == "republish"
+	var condition queue.RepublishConditionFunc = func(j *queue.Job) bool {
+		return string(j.Raw) == "republish"
 	}
 
-	err = queue.RepublishBuried(condition)
+	err = q.RepublishBuried(condition)
 	require.NoError(t, err)
 
-	jobIter, err := queue.Consume(1)
+	jobIter, err := q.Consume(1)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, jobIter.Close()) }()
 
 	job, err := jobIter.Next()
 	require.NoError(t, err)
-	require.Equal(t, string(job.raw), "republish")
+	require.Equal(t, string(job.Raw), "republish")
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,49 @@
+package queue_test
+
+import (
+	"fmt"
+	"log"
+
+	"gopkg.in/src-d/go-queue.v0"
+	_ "gopkg.in/src-d/go-queue.v0/memory"
+)
+
+func ExampleMemoryQueue() {
+	b, err := queue.NewBroker("memory://")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	q, err := b.Queue("test-queue")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	j, err := queue.NewJob()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := j.Encode("hello world!"); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := q.Publish(j); err != nil {
+		log.Fatal(err)
+	}
+
+	iter, err := q.Consume(1)
+
+	consumedJob, err := iter.Next()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var payload string
+	if err := consumedJob.Decode(&payload); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(payload)
+	// Output: hello world!
+}

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -3,6 +3,9 @@ package queue
 import (
 	"testing"
 
+	queue "gopkg.in/src-d/go-queue.v0"
+	"gopkg.in/src-d/go-queue.v0/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -12,23 +15,23 @@ func TestMemorySuite(t *testing.T) {
 }
 
 type MemorySuite struct {
-	QueueSuite
+	test.QueueSuite
 }
 
 func (s *MemorySuite) SetupSuite() {
-	s.BrokerURI = testMemoryURI
+	s.BrokerURI = "memory://"
 	s.AdvWindowNotSupported = true
 }
 
 func (s *MemorySuite) TestIntegration() {
 	assert := assert.New(s.T())
 
-	qName := newName()
+	qName := test.NewName()
 	q, err := s.Broker.Queue(qName)
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	j, err := NewJob()
+	j, err := queue.NewJob()
 	assert.NoError(err)
 
 	j.Encode(true)
@@ -36,7 +39,7 @@ func (s *MemorySuite) TestIntegration() {
 	assert.NoError(err)
 
 	for i := 0; i < 100; i++ {
-		job, err := NewJob()
+		job, err := queue.NewJob()
 		assert.NoError(err)
 
 		job.Encode(true)
@@ -57,7 +60,6 @@ func (s *MemorySuite) TestIntegration() {
 	assert.NoError(err)
 	assert.True(payload)
 
-	assert.Equal(j.tag, retrievedJob.tag)
 	assert.Equal(j.Priority, retrievedJob.Priority)
 	assert.Equal(j.Timestamp.Second(), retrievedJob.Timestamp.Second())
 

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -3,7 +3,7 @@ package queue
 import (
 	"testing"
 
-	queue "gopkg.in/src-d/go-queue.v0"
+	"gopkg.in/src-d/go-queue.v0"
 	"gopkg.in/src-d/go-queue.v0/test"
 
 	"github.com/stretchr/testify/assert"

--- a/register.go
+++ b/register.go
@@ -1,0 +1,50 @@
+package queue
+
+import (
+	"net/url"
+
+	errors "gopkg.in/src-d/go-errors.v0"
+)
+
+var (
+	// ErrUnsupportedProtocol is the error returned when a Broker does not know
+	// how to connect to a given URI.
+	ErrUnsupportedProtocol = errors.NewKind("unsupported protocol: %s")
+	// ErrMalformedURI is the error returned when a Broker does not know
+	// how to parse a given URI.
+	ErrMalformedURI = errors.NewKind("malformed conection URI: %s")
+
+	register = make(map[string]BrokerBuilder, 0)
+)
+
+// BrokerBuilder function that instanciates a new brocked based on the given uri.
+type BrokerBuilder func(uri string) (Broker, error)
+
+// Register registers a new BrokerBuilder to be used by NewBroker, this function
+// should be used in an init function in the implementation packages sush as
+// `amqp` and `memory`.
+func Register(name string, b BrokerBuilder) {
+	register[name] = b
+}
+
+// NewBroker creates a new Broker based on the given URI. In order to register
+// different implementations the package should be imported, example:
+//
+// import _ "gopkg.in/src-d/go-queue.v0/amqp"
+func NewBroker(uri string) (Broker, error) {
+	url, err := url.Parse(uri)
+	if err != nil {
+		return nil, ErrMalformedURI.Wrap(err, uri)
+	}
+
+	if url.Scheme == "" {
+		return nil, ErrMalformedURI.New(uri)
+	}
+
+	b, ok := register[url.Scheme]
+	if !ok {
+		return nil, ErrUnsupportedProtocol.New(url.Scheme)
+	}
+
+	return b(uri)
+}

--- a/register.go
+++ b/register.go
@@ -21,7 +21,7 @@ var (
 type BrokerBuilder func(uri string) (Broker, error)
 
 // Register registers a new BrokerBuilder to be used by NewBroker, this function
-// should be used in an init function in the implementation packages sush as
+// should be used in an init function in the implementation packages such as
 // `amqp` and `memory`.
 func Register(name string, b BrokerBuilder) {
 	register[name] = b

--- a/register_test.go
+++ b/register_test.go
@@ -9,27 +9,11 @@ import (
 func TestNewBroker(t *testing.T) {
 	assert := assert.New(t)
 
-	b, err := NewBroker(testAMQPURI)
-	assert.NoError(err)
-	assert.IsType(&AMQPBroker{}, b)
-	assert.NoError(b.Close())
-
-	b, err = NewBroker("amqp://badurl")
-	assert.Error(err)
-
-	b, err = NewBroker(testMemoryURI)
-	assert.NoError(err)
-	assert.IsType(&memoryBroker{}, b)
-	assert.NoError(b.Close())
-
-	b, err = NewBroker("memory://anything")
-	assert.NoError(err)
-	assert.IsType(&memoryBroker{}, b)
-	assert.NoError(b.Close())
-
-	b, err = NewBroker("badproto://badurl")
+	b, err := NewBroker("badproto://badurl")
 	assert.True(ErrUnsupportedProtocol.Is(err))
+	assert.Nil(b)
 
 	b, err = NewBroker("foo://host%10")
 	assert.Error(err)
+	assert.Nil(b)
 }

--- a/register_test.go
+++ b/register_test.go
@@ -1,0 +1,35 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBroker(t *testing.T) {
+	assert := assert.New(t)
+
+	b, err := NewBroker(testAMQPURI)
+	assert.NoError(err)
+	assert.IsType(&AMQPBroker{}, b)
+	assert.NoError(b.Close())
+
+	b, err = NewBroker("amqp://badurl")
+	assert.Error(err)
+
+	b, err = NewBroker(testMemoryURI)
+	assert.NoError(err)
+	assert.IsType(&memoryBroker{}, b)
+	assert.NoError(b.Close())
+
+	b, err = NewBroker("memory://anything")
+	assert.NoError(err)
+	assert.IsType(&memoryBroker{}, b)
+	assert.NoError(b.Close())
+
+	b, err = NewBroker("badproto://badurl")
+	assert.True(ErrUnsupportedProtocol.Is(err))
+
+	b, err = NewBroker("foo://host%10")
+	assert.Error(err)
+}

--- a/test/suite.go
+++ b/test/suite.go
@@ -7,9 +7,10 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/src-d/go-queue.v0"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	queue "gopkg.in/src-d/go-queue.v0"
 )
 
 var testRand *rand.Rand


### PR DESCRIPTION
This PR changes the implementation of the different queue to a pattern where allows extensibility without modification of the code. Allowing to register different implementation following the database pattern for the standard library

This is an example of the new usage, where the implementation should be imported:

```go
import (
	"fmt"
	"log"

	"gopkg.in/src-d/go-queue.v0"
	_ "gopkg.in/src-d/go-queue.v0/memory"
)

func main() {
	b, err := queue.NewBroker("memory://")
	if err != nil {
		log.Fatal(err)
	}
```