### PR TITLE
Fix memory queue not blocking on Next

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"io"
 	"sync"
 	"time"
 
@@ -161,7 +162,7 @@ func (i *JobIter) next() (*queue.Job, error) {
 	i.Lock()
 	defer i.Unlock()
 	if len(i.q.jobs) <= i.q.idx {
-		return nil, nil
+		return nil, io.EOF
 	}
 
 	j := i.q.jobs[i.q.idx]

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -20,7 +20,6 @@ type MemorySuite struct {
 
 func (s *MemorySuite) SetupSuite() {
 	s.BrokerURI = "memory://"
-	s.AdvWindowNotSupported = true
 }
 
 func (s *MemorySuite) TestIntegration() {


### PR DESCRIPTION
There is a bug in the memory queue. It does not block on `Next()`, instead it returns a `nil` job.

If `next` [returns `nil, nil`]( https://github.com/src-d/go-queue/blob/41c6976a5ba2da67c8c1bf211b6337e35d1ddd6c/memory/memory.go#L164), this [`if` condition](https://github.com/src-d/go-queue/blob/41c6976a5ba2da67c8c1bf211b6337e35d1ddd6c/memory/memory.go#L151) is never true and `Next` returns a `nil` job, instead of blocking until the queue has a new job.

Digging a bit I found these two commits, that as far as I can see can be safely reverted:

65798d3a4cb44ef5bc11daf9c1a8340684957f77
6757b6d3ac1a5dd4afcd0a36a18c75f9d37166f5

cc @erizocosmico 
