### PR TITLE
Upgrade ci system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
   - 1.10.x
-  - tip
 
 go_import_path: gopkg.in/src-d/go-queue.v1
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,10 @@ PROJECT = go-queue
 COMMANDS =
 
 # Including ci Makefile
-MAKEFILE = Makefile.main
-CI_REPOSITORY = https://github.com/src-d/ci.git
-CI_FOLDER = .ci
-
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
+CI_PATH ?= .ci
+MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
-	cp $(CI_FOLDER)/$(MAKEFILE) .;
-
+	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -15,11 +16,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// RabbitMQ tests require running docker.
+// RabbitMQ reconnect tests require running docker.
 // If `docker ps` command returned an error we skip some of the tests.
 var (
 	dockerIsRunning bool
 	dockerCmdOutput string
+	inAppVeyor      bool
 )
 
 func init() {
@@ -27,6 +29,7 @@ func init() {
 	b, err := cmd.CombinedOutput()
 
 	dockerCmdOutput, dockerIsRunning = string(b), (err == nil)
+	inAppVeyor = os.Getenv("APPVEYOR") == "True"
 }
 
 func TestAMQPSuite(t *testing.T) {
@@ -226,7 +229,7 @@ func TestAMQPRepublishBuried(t *testing.T) {
 }
 
 func TestReconnect(t *testing.T) {
-	if !dockerIsRunning {
+	if inAppVeyor || !dockerIsRunning {
 		t.Skip()
 	}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - mingw32-make ci-install
 
 test_script:
-  - mingw32-make ci-script
+  - mingw32-make test
 
 build: off
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,22 @@
 version: "{build}"
+image: Visual Studio 2017
 platform: x64
 
 clone_folder: c:\gopath\src\gopkg.in\src-d\go-queue.v1
 
 environment:
   GOPATH: c:\gopath
+  RABBITMQ_VERSION: any
 
-before_test:
-  - set PATH=C:\Program Files\erl9.2\bin;%PATH%
-  - choco install rabbitmq --ignoredependencies -y
-  - ps: Start-Sleep -s 2
+cache:
+  - C:\Users\appveyor\AppData\Local\Temp\chocolatey\ -> appveyor.yml
 
-build_script:
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
-  - go version
-  - go get -v -t ./...
+install:
+  - set PATH=%GOPATH%\bin;C:\go\bin;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin;%PATH%;"C:\Program Files\Git\mingw64\bin"
+  - mingw32-make ci-install
 
 test_script:
-  - go test -v ./...
+  - mingw32-make ci-script
+
+build: off
+deploy: off


### PR DESCRIPTION
* Upgrade ci to v1
* Disable queue reconnect test in appveyor as it uses docker restart
* appveyor: Use ci system to install rabbitmq. This fixes #10 
* travis: disable building tip and change versions to 1.11 and 1.10