### PR TITLE
Support int16 and int64 in retries header

### DIFF
--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -634,7 +635,11 @@ func fromDelivery(d *amqp.Delivery) (*queue.Job, error) {
 			j.Retries = int32(r)
 
 		case int64:
-			j.Retries = int32(r)
+			if r <= math.MaxInt32 {
+				j.Retries = int32(r)
+			} else {
+				j.Retries = 0
+			}
 
 		default:
 			err = d.Reject(false)


### PR DESCRIPTION
Some messages in borges returned the number of retries as an `int64` number and this was generating errors.

It also rejects messages with malformed headers. If not the messages will be unacked and eventually block the channel.